### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,27 @@
+name: Compile Examples
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   strategy:
+     matrix:
+       fqbn: [
+         "arduino:samd:mkr1000",
+         "arduino:samd:mkrzero",
+         "arduino:samd:mkrwifi1010",
+         "arduino:samd:mkrfox1200",
+         "arduino:samd:mkrwan1300",
+         "arduino:samd:mkrwan1310",
+         "arduino:samd:mkrgsm1400",
+         "arduino:samd:mkrnb1500",
+         "arduino:samd:mkrvidor4000"
+       ]
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/compile-examples@master
+       with:
+         fqbn: ${{ matrix.fqbn }}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/spell-check@master
+       with:
+         ignore-words-list: "./extras/codespell-ignore-words-list.txt"

--- a/extras/codespell-ignore-words-list.txt
+++ b/extras/codespell-ignore-words-list.txt
@@ -1,0 +1,6 @@
+thru
+creat
+pixes
+objec
+conjuction
+indicies


### PR DESCRIPTION
On every push and pull request, all the example sketches will be compiled for MKR Zero and all files in the repository will be checked for misspelled words.

The `spell-check` action found some misspelled words in the spiffs* files. Since this is an external dependency, fixing the true positives among these in this repository would lead to difficulty merging subsequent releases of spiffs. So I have added the true and false positives to `extras/codespell-ignore-words-list.txt`. I have submitted a PR upstream to fix the true positives: https://github.com/pellepl/spiffs/pull/254. Once that is merged and pulled into this repo, the true positives may be removed from the list to avoid an increased possibility of false negatives.